### PR TITLE
🐛 Fix: Conflict in version naming

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,8 +38,8 @@ jobs:
       # Deployment to 'main' service
       - name: Deploy to Main Service
         if: github.ref == 'refs/heads/main'
-        run: gcloud app deploy app.yaml --project ${{secrets.GCP_PROJECT_ID}} --promote --version main
+        run: gcloud app deploy app.yaml --project ${{secrets.GCP_PROJECT_ID}} --promote
       # Deployment to 'staging' service
       - name: Deploy to Staging Service
         if: github.ref == 'refs/heads/staging'
-        run: gcloud app deploy app.yaml --project ${{secrets.GCP_PROJECT_ID}} --no-promote --version staging
+        run: gcloud app deploy app.yaml --project ${{secrets.GCP_PROJECT_ID}} --no-promote


### PR DESCRIPTION
• Same version name results in conflict
• Removing static naming solves the issue
• The key lies in the flags (`--promote` for production, `--no-promote` for staging)