### PR TITLE
🐛 Fix: Google Cloud deployment error

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,7 +1,7 @@
  # –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
  # # `.gcloudignore`
  # @organization: Semantyk
- * @project: Client
+ # @project: Client
  #
  # This file contains the list of files and folders that are ignored by
  # Google Cloud.

--- a/app.yaml
+++ b/app.yaml
@@ -21,5 +21,3 @@ instance_class: F1
 
 automatic_scaling:
   max_instances: 1
-
-entrypoint: npm start


### PR DESCRIPTION
- `.gcloudignore` had an "*" in the header that was excluding everything